### PR TITLE
VecMat.vcxprojのビルド設定を更新

### DIFF
--- a/VecMat.vcxproj
+++ b/VecMat.vcxproj
@@ -71,6 +71,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <IncludePath>$(ProjectDir)math;$(IncludePath)</IncludePath>
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\MiddleBuild</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <IncludePath>$(ProjectDir)math;$(IncludePath)</IncludePath>
@@ -84,6 +85,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -100,6 +102,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
VecMat.vcxprojファイルに以下の変更を加えました：
- `Debug|x64`構成において、中間ビルドディレクトリ（`IntDir`）を追加し、中間ファイルが`$(SolutionDir)$(Configuration)\MiddleBuild`ディレクトリに出力されるようにしました。
- `Debug`構成のコンパイル設定で、ランタイムライブラリを`MultiThreadedDebug`に設定しました。
- `Release`構成のコンパイル設定で、ランタイムライブラリを`MultiThreaded`に設定しました。