### PR TITLE
Release構成に中間ビルドディレクトリを追加

### DIFF
--- a/VecMat.vcxproj
+++ b/VecMat.vcxproj
@@ -76,6 +76,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <IncludePath>$(ProjectDir)math;$(IncludePath)</IncludePath>
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)$(Configuration)\MiddleBuild</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>


### PR DESCRIPTION
`VecMat.vcxproj`ファイルの`Release|x64`構成に新しい`<IntDir>`要素を追加しました。この要素は中間ビルドディレクトリを指定し、`$(SolutionDir)$(Configuration)\MiddleBuild`に設定されています。これにより、リリース構成のビルド時に中間ファイルが保存されるディレクトリが指定されます。