### PR TITLE
Feature/matrix3x3

### DIFF
--- a/Project/VecMat.vcxproj
+++ b/Project/VecMat.vcxproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ClInclude Include="..\math\Color.h" />
     <ClInclude Include="..\math\MathExtension\mathExtension.h" />
+    <ClInclude Include="..\math\Matrix3x3.h" />
     <ClInclude Include="..\math\Matrix4x4.h" />
     <ClInclude Include="..\math\Quaternion.h" />
     <ClInclude Include="..\math\Rect2.h" />
@@ -25,6 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\math\impl\Color.cpp" />
+    <ClCompile Include="..\math\impl\Matrix3x3.cpp" />
     <ClCompile Include="..\math\impl\Matrix4x4.cpp" />
     <ClCompile Include="..\math\impl\Quaternion.cpp" />
     <ClCompile Include="..\math\impl\Rect2.cpp" />

--- a/math/Matrix3x3.h
+++ b/math/Matrix3x3.h
@@ -1,0 +1,46 @@
+#pragma once
+
+/// ‘O•ûéŒ¾
+class Vector2;
+
+/// <summary>
+/// 3x3s—ñ
+/// </summary>
+class Matrix3x3 final 
+{
+public:
+    Matrix3x3() = default;
+    ~Matrix3x3() = default;
+
+    float m[3][3];
+
+    /// ====================
+    /// Minus Sign
+    /// ====================
+    
+    Matrix3x3 operator-() const;
+
+    /// =====================
+    /// Make Matrix
+    /// =====================
+    
+    static Matrix3x3 Identity();
+    static Matrix3x3 RotateMatrix(float _radian);
+    static Matrix3x3 ScaleMatrix(const Vector2& _scale);
+    static Matrix3x3 TranslateMatrix(const Vector2& _translate);
+
+    /// ====================
+    /// Operator
+    /// ====================
+    
+    Matrix3x3& operator +=(const Matrix3x3& _rm);
+    Matrix3x3& operator -=(const Matrix3x3& _rm);
+    Matrix3x3& operator *=(const Matrix3x3& _rm);
+
+    Matrix3x3 operator +(const Matrix3x3& _rm) const;
+    Matrix3x3 operator -(const Matrix3x3& _rm) const;
+    Matrix3x3 operator *(const Matrix3x3& _rm) const;
+
+    Matrix3x3& operator *=(float _f);
+    Matrix3x3 operator *(float _f) const;
+};

--- a/math/impl/Matrix3x3.cpp
+++ b/math/impl/Matrix3x3.cpp
@@ -1,0 +1,202 @@
+#include "../Matrix3x3.h"
+
+#include "../Vector2.h"
+
+#include <cmath>
+
+Matrix3x3 Matrix3x3::operator -() const
+{
+    Matrix3x3 result = {};
+
+    for (int i = 0; i < 3; i++)
+    {
+        for (int j = 0; j < 3; j++)
+        {
+            result.m[i][j] = -m[i][j];
+        }
+    }
+
+    return result;
+}
+
+Matrix3x3 Matrix3x3::Identity()
+{
+    Matrix3x3 result = {};
+    result.m[0][0] = 1.0f;
+    result.m[0][1] = 0.0f;
+    result.m[0][2] = 0.0f;
+    result.m[1][0] = 0.0f;
+    result.m[1][1] = 1.0f;
+    result.m[1][2] = 0.0f;
+    result.m[2][0] = 0.0f;
+    result.m[2][1] = 0.0f;
+    result.m[2][2] = 1.0f;
+
+    return result;
+}
+
+Matrix3x3 Matrix3x3::RotateMatrix(float _radian)
+{
+    Matrix3x3 result = {};
+    result.m[0][0] = std::cosf(_radian);
+    result.m[0][1] = -std::sinf(_radian);
+    result.m[0][2] = 0.0f;
+    result.m[1][0] = std::sinf(_radian);
+    result.m[1][1] = std::cosf(_radian);
+    result.m[1][2] = 0.0f;
+    result.m[2][0] = 0.0f;
+    result.m[2][1] = 0.0f;
+    result.m[2][2] = 1.0f;
+
+    return result;
+}
+
+Matrix3x3 Matrix3x3::ScaleMatrix(const Vector2& _scale)
+{
+    Matrix3x3 result = {};
+    result.m[0][0] = _scale.x;
+    result.m[0][1] = 0.0f;
+    result.m[0][2] = 0.0f;
+    result.m[1][0] = 0.0f;
+    result.m[1][1] = _scale.y;
+    result.m[1][2] = 0.0f;
+    result.m[2][0] = 0.0f;
+    result.m[2][1] = 0.0f;
+    result.m[2][2] = 1.0f;
+
+    return result;
+}
+
+Matrix3x3 Matrix3x3::TranslateMatrix(const Vector2& _translate)
+{
+    Matrix3x3 result = {};
+    result.m[0][0] = 1.0f;
+    result.m[0][1] = 0.0f;
+    result.m[0][2] = 0.0f;
+    result.m[1][0] = 0.0f;
+    result.m[1][1] = 1.0f;
+    result.m[1][2] = 0.0f;
+    result.m[2][0] = _translate.x;
+    result.m[2][1] = _translate.y;
+    result.m[2][2] = 1.0f;
+
+    return result;
+}
+
+Matrix3x3& Matrix3x3::operator +=(const Matrix3x3& _rm)
+{
+    for (int i = 0; i < 3; i++)
+    {
+        for (int j = 0; j < 3; j++)
+        {
+            m[i][j] += _rm.m[i][j];
+        }
+    }
+
+    return *this;
+}
+
+Matrix3x3& Matrix3x3::operator -=(const Matrix3x3& _rm)
+{
+    for (int i = 0; i < 3; i++)
+    {
+        for (int j = 0; j < 3; j++)
+        {
+            m[i][j] -= _rm.m[i][j];
+        }
+    }
+
+    return *this;
+}
+
+Matrix3x3& Matrix3x3::operator *=(const Matrix3x3& _rm)
+{
+    for (int off = 0; off < 3; off++)
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            for (int j = 0; j < 3; j++)
+            {
+                m[off][i] += m[off][j] * _rm.m[j][i];
+            }
+        }
+    }
+
+    return *this;
+}
+
+Matrix3x3 Matrix3x3::operator +(const Matrix3x3& _rm) const
+{
+    Matrix3x3 result = {};
+
+    for (int i = 0; i < 3; i++)
+    {
+        for (int j = 0; j < 3; j++)
+        {
+            result.m[i][j] = m[i][j] + _rm.m[i][j];
+        }
+    }
+
+    return result;
+}
+
+Matrix3x3 Matrix3x3::operator -(const Matrix3x3& _rm) const
+{
+    Matrix3x3 result = {};
+    for (int i = 0; i < 3; i++)
+    {
+        for (int j = 0; j < 3; j++)
+        {
+            result.m[i][j] = m[i][j] - _rm.m[i][j];
+        }
+    }
+
+    return result;
+}
+
+Matrix3x3 Matrix3x3::operator *(const Matrix3x3& _rm) const
+{
+    Matrix3x3 result = {};
+
+    for (int off = 0; off < 3; off++)
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            for (int j = 0; j < 3; j++)
+            {
+                result.m[off][i] += m[off][j] * _rm.m[j][i];
+            }
+        }
+    }
+
+    return result;
+}
+
+Matrix3x3& Matrix3x3::operator *=(float _f)
+{
+    for (int i = 0; i < 3; i++)
+    {
+        for (int j = 0; j < 3; j++)
+        {
+            m[i][j] *= _f;
+        }
+    }
+
+    return *this;
+}
+
+Matrix3x3 Matrix3x3::operator *(float _f) const
+{
+    Matrix3x3 result = {};
+
+    for (int i = 0; i < 3; i++)
+    {
+        for (int j = 0; j < 3; j++)
+        {
+            result.m[i][j] = m[i][j] * _f;
+        }
+    }
+
+    return result;
+}
+

--- a/math/impl/Matrix4x4.cpp
+++ b/math/impl/Matrix4x4.cpp
@@ -472,14 +472,13 @@ Matrix4x4& Matrix4x4::operator-=(const Matrix4x4& _rm)
 
 Matrix4x4& Matrix4x4::operator*=(const Matrix4x4& _rm)
 {
-    for (int i = 0; i < 4; i++)
-    {
-        for (int j = 0; j < 4; j++)
-        {
-            m[i][j] *= _rm.m[i][j];
-        }
-    }
+    for (int off = 0; off < 4; off++)
+        for (int i = 0; i < 4; i++)
+            for (int j = 0; j < 4; j++)
+                m[off][i] += m[off][j] * _rm.m[j][i];
+
     return *this;
+
 }
 
 Matrix4x4 Matrix4x4::operator*(const Matrix4x4& _rm) const

--- a/math/impl/Matrix4x4.cpp
+++ b/math/impl/Matrix4x4.cpp
@@ -478,7 +478,6 @@ Matrix4x4& Matrix4x4::operator*=(const Matrix4x4& _rm)
                 m[off][i] += m[off][j] * _rm.m[j][i];
 
     return *this;
-
 }
 
 Matrix4x4 Matrix4x4::operator*(const Matrix4x4& _rm) const


### PR DESCRIPTION
## 変更内容

### VecMat.vcxproj
- `Matrix3x3.h` と `Matrix3x3.cpp` のインクルードを追加

### Matrix4x4
- `Matrix4x4.cpp` の `Matrix4x4& Matrix4x4::operator*=(const Matrix4x4& _rm)` メソッドを修正し、行列の積の計算を正しく行うように修正

### Matrix3x3
- `Matrix3x3.h` ファイルを新規追加
  - 3x3行列を扱う `Matrix3x3` クラスを定義
  - 行列の初期化、回転、スケーリング、平行移動のための静的メソッドや演算子オーバーロードを含む
- `Matrix3x3.cpp` ファイルを新規追加
  - `Matrix3x3` クラスのメソッドを実装
  - 行列の初期化、回転、スケーリング、平行移動のためのメソッドや演算子オーバーロードの実装を含む