### PR TITLE
add: RGBAコンストラクタをColor.hに追加

### DIFF
--- a/math/Color.h
+++ b/math/Color.h
@@ -91,6 +91,7 @@ public:
 
     RGBA(uint8_t _r, uint8_t _g, uint8_t _b, uint8_t _a) : r_(_r), g_(_g), b_(_b), a_(_a) {}
     RGBA(const RGBA& _other) : r_(_other.r_), g_(_other.g_), b_(_other.b_), a_(_other.a_) {}
+    RGBA(uint32_t _rgba) : r_((_rgba >> 24) & 0xFF), g_((_rgba >> 16) & 0xFF), b_((_rgba >> 8) & 0xFF), a_(_rgba & 0xFF) {}
     RGBA(RGBA&& _other) : r_(_other.r_), g_(_other.g_), b_(_other.b_), a_(_other.a_) {}
 
     RGBA& operator=(const RGBA& other)


### PR DESCRIPTION
* `Color.h`に新しいコンストラクタ`RGBA(uint32_t _rgba)`が追加されました。このコンストラクタは、32ビットのRGBA値を受け取り、各色成分（赤、緑、青、アルファ）をビットシフトとマスクを使用して初期化します。

バイナリファイルやJSONの変更はありません。